### PR TITLE
Corne firmware, correct nano nice, improve VIA note

### DIFF
--- a/docs/build-guides/corne-wireless/firmware.mdx
+++ b/docs/build-guides/corne-wireless/firmware.mdx
@@ -6,7 +6,7 @@ import DefaultKeymap5Col from './5_col_default_keymap.svg';
 
 # Firmware
 
-If you're not familiar, ZMK is a wireless-focused firmware, and it powers our Corne Wireless. While it doesn't have a VIA alternative yet, it does allow you to build firmware in the cloud.
+If you're not familiar, ZMK is a wireless-focused firmware, and it powers our Corne Wireless. While [ZMK Studio](https://zmk.studio/) is not as full featured as [VIA](https://www.caniusevia.com/) yet, [the team is working hard at improving it](https://zmk.dev/docs/features/studio).
 
 If you want to get running quickly, you can use our default firmware files. These are pre-compiled but are not guaranteed to have the most up-to-date version of ZMK. Check how to install these files in the ["Installing Firmware"](#installing-firmware) section at the bottom of this page
 
@@ -14,12 +14,12 @@ If you want to get running quickly, you can use our default firmware files. Thes
 
 |                  | ⬅️ Left Half | ➡️ Right Half |
 |------------------|--------------|---------------|
-| 🚫 **nice!view** |[Download](/assets/6_col_corne_left-nice_nano_v2-zmk.uf2)|[Download](/assets/6_col_corne_right-nice_nano_v2-zmk.uf2)|
+| 🚫 **nice!nano** |[Download](/assets/6_col_corne_left-nice_nano_v2-zmk.uf2)|[Download](/assets/6_col_corne_right-nice_nano_v2-zmk.uf2)|
 | ✅ **nice!view** |[Download](/assets/6_col_corne_left-nice_view_adapter-nice_view-nice_nano_v2-zmk.uf2)|[Download](/assets/6_col_corne_right-nice_view_adapter-nice_view-nice_nano_v2-zmk.uf2)|
 
 ## Keymap Customization with ZMK Studio
 
-ZMK Studio provides runtime update functionality to ZMK powered devices, allowing users to change their keymap layers without flashing new firmware to their keyboards.
+[ZMK Studio](https://zmk.studio/) provides runtime update functionality to ZMK powered devices, allowing users to change their keymap layers without flashing new firmware to their keyboards.
 
 The firmware files provided above are compatible with ZMK Studio. You can use the firmware files to flash your Lily58 Wireless and then use ZMK Studio to customize your keymap.
 
@@ -40,7 +40,7 @@ To use the native app for Linux, macOS, or Windows, download the appropriate fil
 
 |                  | ⬅️ Left Half | ➡️ Right Half |
 |------------------|--------------|---------------|
-| 🚫 **nice!view** |[Download](/assets/5_col_corne_left-nice_nano_v2-zmk.uf2)|[Download](/assets/5_col_corne_right-nice_nano_v2-zmk.uf2)|
+| 🚫 **nice!nano** |[Download](/assets/5_col_corne_left-nice_nano_v2-zmk.uf2)|[Download](/assets/5_col_corne_right-nice_nano_v2-zmk.uf2)|
 | ✅ **nice!view** |[Download](/assets/5_col_corne_left-nice_view_adapter-nice_view-nice_nano_v2-zmk.uf2)|[Download](/assets/5_col_corne_right-nice_view_adapter-nice_view-nice_nano_v2-zmk.uf2)|
 
 
@@ -61,7 +61,7 @@ With the nature of a small keyboard like the Corne, you're likely interested in 
 We've created ZMK config repositories for the Corne Wireless for you to use as a template for yourself. If you'd like to set it up manually, follow the [ZMK documentation](https://zmk.dev/docs/user-setup).
 
 ### Repos
-| Columns | 🚫 nice!view | ✅ nice!view |
+| Columns | 🚫 nice!nano | ✅ nice!view |
 |---------|--------------|--------------|
 |6|[Repository](https://github.com/typeractivexyz/corne-wireless-zmk-config)|[Repository](https://github.com/typeractivexyz/corne-wireless-view-zmk-config)|
 |5|[Repository](https://github.com/typeractivexyz/corne-wireless-5-col-zmk-config)|[Repository](https://github.com/typeractivexyz/corne-wireless-5-col-view-zmk-config)|


### PR DESCRIPTION
This doc still starts with a statement that there is nothing like VIA, but I think ZMK Studio is now here.
Double check, but it seems like the firmware tables are intended to link to firmwares' where there is no nice!view. 