### PR TITLE
Disambiguate rows/cols for the Lily58 & Corne

### DIFF
--- a/docs/build-guides/corne-wireless/corne_pins.svg
+++ b/docs/build-guides/corne-wireless/corne_pins.svg
@@ -7,7 +7,7 @@
    version="1.1"
    id="svg568"
    sodipodi:docname="corne_pins.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -22,14 +22,14 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="1.8526198"
-     inkscape:cx="507.11971"
-     inkscape:cy="158.42431"
-     inkscape:window-width="3840"
-     inkscape:window-height="2071"
-     inkscape:window-x="2691"
-     inkscape:window-y="1155"
-     inkscape:window-maximized="1"
+     inkscape:zoom="1.31"
+     inkscape:cx="383.2061"
+     inkscape:cy="311.45038"
+     inkscape:window-width="2739"
+     inkscape:window-height="1742"
+     inkscape:window-x="1361"
+     inkscape:window-y="235"
+     inkscape:window-maximized="0"
      inkscape:current-layer="g182" />
   <defs
      id="defs572" />
@@ -272,8 +272,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="553.07544"
-       y="601.7605"
+       x="501.42899"
+       y="550.11401"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -281,8 +281,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="582.39984"
-       y="617.65625"
+       x="530.75336"
+       y="566.00977"
        class="tap"
        id="text8-0-17-0"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -290,8 +290,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="513.94153"
-       y="562.62653"
+       x="462.29507"
+       y="510.98007"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -299,8 +299,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="543.26587"
-       y="578.52228"
+       x="491.61942"
+       y="526.87579"
        class="tap"
        id="text8-0-17-9-3"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -308,8 +308,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="474.60452"
-       y="523.28961"
+       x="422.95807"
+       y="471.64316"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -317,8 +317,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="503.92899"
-       y="539.18536"
+       x="452.28253"
+       y="487.53891"
        class="tap"
        id="text8-0-17-2-5"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -326,8 +326,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="435.20807"
-       y="484.01205"
+       x="383.56161"
+       y="432.3656"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -335,8 +335,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="464.53244"
-       y="499.90781"
+       x="412.88599"
+       y="448.26135"
        class="tap"
        id="text8-0-17-7-2"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -344,8 +344,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="395.87112"
-       y="444.67511"
+       x="344.22467"
+       y="393.02866"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -353,8 +353,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="425.1955"
-       y="460.57086"
+       x="373.54904"
+       y="408.92441"
        class="tap"
        id="text8-0-17-8-7"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -362,8 +362,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="356.53415"
-       y="405.33813"
+       x="304.8877"
+       y="353.69168"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -371,8 +371,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="385.85855"
-       y="421.23389"
+       x="334.2121"
+       y="369.58743"
        class="tap"
        id="text8-0-17-83-6"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -482,84 +482,84 @@ path.combo {
     <rect
        rx="6"
        ry="6"
-       x="530.20435"
+       x="457.16525"
        y="84.520905"
        width="52"
        height="52"
        class="key"
        id="rect30" />
     <text
-       x="556.20435"
+       x="483.16525"
        y="110.5209"
        class="tap"
        id="text32">Y</text>
     <rect
        rx="6"
        ry="6"
-       x="586.20435"
+       x="513.16522"
        y="77.520905"
        width="52"
        height="52"
        class="key"
        id="rect34" />
     <text
-       x="612.20435"
+       x="539.16522"
        y="103.5209"
        class="tap"
        id="text36">U</text>
     <rect
        rx="6"
        ry="6"
-       x="642.20435"
+       x="569.16522"
        y="70.520905"
        width="52"
        height="52"
        class="key"
        id="rect38" />
     <text
-       x="668.20435"
+       x="595.16522"
        y="96.520905"
        class="tap"
        id="text40">I</text>
     <rect
        rx="6"
        ry="6"
-       x="698.20435"
+       x="625.16522"
        y="77.520905"
        width="52"
        height="52"
        class="key"
        id="rect42" />
     <text
-       x="724.20435"
+       x="651.16522"
        y="103.5209"
        class="tap"
        id="text44">O</text>
     <rect
        rx="6"
        ry="6"
-       x="754.20435"
+       x="681.16522"
        y="91.520905"
        width="52"
        height="52"
        class="key"
        id="rect46" />
     <text
-       x="780.20435"
+       x="707.16522"
        y="117.5209"
        class="tap"
        id="text48">P</text>
     <rect
        rx="6"
        ry="6"
-       x="810.20435"
+       x="737.16522"
        y="91.520905"
        width="52"
        height="52"
        class="key"
        id="rect50" />
     <text
-       x="836.20435"
+       x="763.16522"
        y="117.5209"
        class="tap"
        id="text52">BSPC</text>
@@ -650,84 +650,84 @@ path.combo {
     <rect
        rx="6"
        ry="6"
-       x="530.20435"
+       x="457.16525"
        y="140.5209"
        width="52"
        height="52"
        class="key"
        id="rect78" />
     <text
-       x="556.20435"
+       x="483.16525"
        y="166.5209"
        class="tap"
        id="text80">H</text>
     <rect
        rx="6"
        ry="6"
-       x="586.20435"
+       x="513.16522"
        y="133.5209"
        width="52"
        height="52"
        class="key"
        id="rect82" />
     <text
-       x="612.20435"
+       x="539.16522"
        y="159.5209"
        class="tap"
        id="text84">J</text>
     <rect
        rx="6"
        ry="6"
-       x="642.20435"
+       x="569.16522"
        y="126.5209"
        width="52"
        height="52"
        class="key"
        id="rect86" />
     <text
-       x="668.20435"
+       x="595.16522"
        y="152.5209"
        class="tap"
        id="text88">K</text>
     <rect
        rx="6"
        ry="6"
-       x="698.20435"
+       x="625.16522"
        y="133.5209"
        width="52"
        height="52"
        class="key"
        id="rect90" />
     <text
-       x="724.20435"
+       x="651.16522"
        y="159.5209"
        class="tap"
        id="text92">L</text>
     <rect
        rx="6"
        ry="6"
-       x="754.20435"
+       x="681.16522"
        y="147.5209"
        width="52"
        height="52"
        class="key"
        id="rect94" />
     <text
-       x="780.20435"
+       x="707.16522"
        y="173.5209"
        class="tap"
        id="text96">;</text>
     <rect
        rx="6"
        ry="6"
-       x="810.20435"
+       x="737.16522"
        y="147.5209"
        width="52"
        height="52"
        class="key"
        id="rect98" />
     <text
-       x="836.20435"
+       x="763.16522"
        y="173.5209"
        class="tap"
        id="text100">'</text>
@@ -818,104 +818,108 @@ path.combo {
     <rect
        rx="6"
        ry="6"
-       x="530.20435"
+       x="457.16525"
        y="196.5209"
        width="52"
        height="52"
        class="key"
        id="rect126" />
     <text
-       x="556.20435"
+       x="483.16525"
        y="222.5209"
        class="tap"
        id="text128">N</text>
     <rect
        rx="6"
        ry="6"
-       x="586.20435"
+       x="513.16522"
        y="189.5209"
        width="52"
        height="52"
        class="key"
        id="rect130" />
     <text
-       x="612.20435"
+       x="539.16522"
        y="215.5209"
        class="tap"
        id="text132">M</text>
     <rect
        rx="6"
        ry="6"
-       x="642.20435"
+       x="569.16522"
        y="182.5209"
        width="52"
        height="52"
        class="key"
        id="rect134" />
     <text
-       x="668.20435"
+       x="595.16522"
        y="208.5209"
        class="tap"
        id="text136">,</text>
     <rect
        rx="6"
        ry="6"
-       x="698.20435"
+       x="625.16522"
        y="189.5209"
        width="52"
        height="52"
        class="key"
        id="rect138" />
     <text
-       x="724.20435"
+       x="651.16522"
        y="215.5209"
        class="tap"
        id="text140">.</text>
     <rect
        rx="6"
        ry="6"
-       x="754.20435"
+       x="681.16522"
        y="203.5209"
        width="52"
        height="52"
        class="key"
        id="rect142" />
     <text
-       x="780.20435"
+       x="707.16522"
        y="229.5209"
        class="tap"
        id="text144">/</text>
     <rect
        rx="6"
        ry="6"
-       x="810.20435"
+       x="737.16522"
        y="203.5209"
        width="52"
        height="52"
        class="key"
        id="rect146" />
     <text
-       x="836.20435"
+       x="763.16522"
        y="229.5209"
        class="tap"
        id="text148">ESC</text>
-    <rect
-       rx="6"
-       ry="6"
-       x="222.20435"
-       y="247.36891"
-       width="52"
-       height="52"
-       class="key"
-       id="rect150" />
-    <text
-       x="248.20435"
-       y="273.3689"
-       class="tap"
-       id="text152">LGUI</text>
     <g
-       transform="rotate(15,265.14933,253.32925)"
-       id="g158">
+       id="g1"
+       transform="translate(-27.999613,-8.8483637)">
+      <rect
+         rx="6"
+         ry="6"
+         x="222.20435"
+         y="247.36891"
+         width="52"
+         height="52"
+         class="key"
+         id="rect150" />
+      <text
+         x="248.20435"
+         y="273.3689"
+         class="tap"
+         id="text152">LGUI</text>
+    </g>
+    <g
+       id="g158"
+       transform="translate(-39.395273,2.4405462)">
       <rect
          rx="6"
          ry="6"
@@ -932,8 +936,8 @@ path.combo {
          id="text156">lower</text>
     </g>
     <g
-       transform="rotate(30,354.85785,275.7256)"
-       id="g164">
+       id="g164"
+       transform="translate(-48.915262,12.240549)">
       <rect
          rx="6"
          ry="6"
@@ -950,8 +954,8 @@ path.combo {
          id="text162">SPACE</text>
     </g>
     <g
-       transform="rotate(-30,539.34649,297.3553)"
-       id="g170">
+       id="g170"
+       transform="translate(-35.714386,12.240549)">
       <rect
          rx="6"
          ry="6"
@@ -968,8 +972,8 @@ path.combo {
          id="text168">RET</text>
     </g>
     <g
-       transform="rotate(-15,629.05501,297.35165)"
-       id="g176">
+       id="g176"
+       transform="translate(-45.234405,2.4405462)">
       <rect
          rx="6"
          ry="6"
@@ -985,20 +989,24 @@ path.combo {
          class="tap"
          id="text174">raise</text>
     </g>
-    <rect
-       rx="6"
-       ry="6"
-       x="614.20435"
-       y="247.36891"
-       width="52"
-       height="52"
-       class="key"
-       id="rect178" />
-    <text
-       x="640.20435"
-       y="273.3689"
-       class="tap"
-       id="text180">RALT</text>
+    <g
+       id="g2"
+       transform="translate(-45.038727,-8.8483637)">
+      <rect
+         rx="6"
+         ry="6"
+         x="614.20435"
+         y="247.36891"
+         width="52"
+         height="52"
+         class="key"
+         id="rect178" />
+      <text
+         x="640.20435"
+         y="273.3689"
+         class="tap"
+         id="text180">RALT</text>
+    </g>
     <rect
        rx="6.7671661"
        ry="5.737287"
@@ -1014,6 +1022,66 @@ path.combo {
        y="285.51407"
        class="tap"
        id="text8-0-8"
+       style="dominant-baseline:middle;text-anchor:middle">P0.11</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="810.77295"
+       y="101.42674"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-13"/>
+    <text
+       x="840.09735"
+       y="117.32249"
+       class="tap"
+       id="text8-0-89"
+       style="dominant-baseline:middle;text-anchor:middle">P0.22</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="810.85156"
+       y="157.63181"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-1-9"/>
+    <text
+       x="840.17596"
+       y="173.52756"
+       class="tap"
+       id="text8-0-4-1"
+       style="dominant-baseline:middle;text-anchor:middle">P0.24</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="810.85156"
+       y="213.62497"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-7-8"/>
+    <text
+       x="840.17596"
+       y="229.52072"
+       class="tap"
+       id="text8-0-1-1"
+       style="dominant-baseline:middle;text-anchor:middle">P1.00</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="810.85156"
+       y="269.61813"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-3-9"/>
+    <text
+       x="840.17596"
+       y="285.51389"
+       class="tap"
+       id="text8-0-8-8"
        style="dominant-baseline:middle;text-anchor:middle">P0.11</text>
   </g>
 </svg>

--- a/docs/build-guides/corne-wireless/troubleshooting.mdx
+++ b/docs/build-guides/corne-wireless/troubleshooting.mdx
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 import CornePins from './corne_pins.svg';
 
-# Troubleshooting
+# Troubleshooting & Pinouts
 
 If you're running into issues with your keyboard, check out our [Troubleshooting](/troubleshooting) page for common issues and solutions. If you're still having trouble, please reach out to use on [Discord](https://typeractive.xyz/discord)!
 
@@ -12,6 +12,28 @@ If you're running into issues with your keyboard, check out our [Troubleshooting
 
 Below you can see which pins on the nice!nano lineup with the Corne's rows and columns.
 
-If you're having issues with a specific row or column, use this diagram along with the [troubleshoting guide](/troubleshooting/rows-columns-not-working) to help you diagnose the issue.
+If you're having issues with a specific row or column, use this diagram along with the [troubleshooting guide](/troubleshooting/rows-columns-not-working) to help you diagnose the issue.
 
 <CornePins />
+
+Definitions can be found in the dtsi for the [Rows](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/corne/corne.dtsi), [Left column](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/corne/corne_left.overlay) and [Right column](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/corne/corne_right.overlay)
+
+## Spare pins
+
+Not all the pins on the nice!nano are used and depending on if you have a nice!view or not the following pins are available:
+
+| 🚫 nice!view  | ✅ nice!view |
+|-------- |-------------|
+| P0.06   | ~~P0.06~~  |
+| P0.08   | P0.08  |
+| P0.17   | ~~P0.17~~  |
+| P0.20   | ~~P0.20~~  |
+| P1.04   | P1.04  |
+| P1.06   | P1.06  |
+| P0.10   | P0.10  |
+| P0.09   | P0.09  |
+| P1.01^  | P1.01^ |
+| P1.02^  | P1.02^ |
+| P1.07^  | P1.07^ |
+
+^ These pins are on the middle of the board rather than on the edges.

--- a/docs/build-guides/lily58-wireless/lily58_pins.svg
+++ b/docs/build-guides/lily58-wireless/lily58_pins.svg
@@ -7,7 +7,7 @@
    version="1.1"
    id="svg568"
    sodipodi:docname="lily58_pins.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -22,13 +22,13 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="2.5269189"
-     inkscape:cx="413.74498"
-     inkscape:cy="207.96077"
-     inkscape:window-width="3840"
-     inkscape:window-height="2071"
-     inkscape:window-x="2691"
-     inkscape:window-y="1155"
+     inkscape:zoom="1.2634595"
+     inkscape:cx="678.29638"
+     inkscape:cy="86.666806"
+     inkscape:window-width="2364"
+     inkscape:window-height="1439"
+     inkscape:window-x="2279"
+     inkscape:window-y="454"
      inkscape:window-maximized="1"
      inkscape:current-layer="g182" />
   <defs
@@ -258,8 +258,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="535.16632"
-       y="583.85138"
+       x="460.73163"
+       y="509.41669"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -267,8 +267,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="564.49072"
-       y="599.74713"
+       x="490.05603"
+       y="525.31244"
        class="tap"
        id="text8-0-17-0"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -276,8 +276,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="496.03244"
-       y="544.71741"
+       x="421.59775"
+       y="470.28271"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -285,8 +285,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="525.35675"
-       y="560.61316"
+       x="450.92206"
+       y="486.17847"
        class="tap"
        id="text8-0-17-9-3"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -294,8 +294,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="456.69543"
-       y="505.38052"
+       x="382.26074"
+       y="430.94583"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -303,8 +303,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="486.0199"
-       y="521.27625"
+       x="411.58521"
+       y="446.84155"
        class="tap"
        id="text8-0-17-2-5"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -312,8 +312,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="417.29898"
-       y="466.10297"
+       x="342.86429"
+       y="391.66827"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -321,8 +321,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="446.62335"
-       y="481.99872"
+       x="372.18866"
+       y="407.56403"
        class="tap"
        id="text8-0-17-7-2"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -330,8 +330,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="613.01892"
-       y="661.82288"
+       x="538.58423"
+       y="587.38824"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -339,8 +339,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="642.34326"
-       y="677.71863"
+       x="567.90857"
+       y="603.284"
        class="tap"
        id="text8-0-17-8-7"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -348,8 +348,8 @@ path.combo {
     <rect
        rx="6.7671661"
        ry="5.737287"
-       x="573.68195"
-       y="622.4859"
+       x="499.24725"
+       y="548.05121"
        width="58.648773"
        height="29.241695"
        class="key"
@@ -357,8 +357,8 @@ path.combo {
        style="stroke-width:0.796393"
        transform="rotate(-45)" />
     <text
-       x="603.00635"
-       y="638.38165"
+       x="528.57166"
+       y="563.94696"
        class="tap"
        id="text8-0-17-83-6"
        style="dominant-baseline:middle;text-anchor:middle"
@@ -425,6 +425,81 @@ path.combo {
        y="347.98819"
        class="tap"
        id="text8-0-8-3"
+       style="dominant-baseline:middle;text-anchor:middle">P1.06</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="871.48743"
+       y="107.65721"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-6" />
+    <text
+       x="900.81189"
+       y="123.55295"
+       class="tap"
+       id="text8-0-3"
+       style="dominant-baseline:middle;text-anchor:middle">P0.24</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="871.56604"
+       y="163.86223"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-1-5" />
+    <text
+       x="900.89044"
+       y="179.75798"
+       class="tap"
+       id="text8-0-4-1"
+       style="dominant-baseline:middle;text-anchor:middle">P1.00</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="871.56604"
+       y="219.85539"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-7-6" />
+    <text
+       x="900.89044"
+       y="235.75114"
+       class="tap"
+       id="text8-0-1-3"
+       style="dominant-baseline:middle;text-anchor:middle">P0.11</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="871.56604"
+       y="275.84854"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-3-45" />
+    <text
+       x="900.89044"
+       y="291.74429"
+       class="tap"
+       id="text8-0-8-2"
+       style="dominant-baseline:middle;text-anchor:middle">P1.04</text>
+    <rect
+       rx="6.7671661"
+       ry="5.737287"
+       x="871.65881"
+       y="331.99084"
+       width="58.648773"
+       height="29.241695"
+       class="key"
+       id="rect6-7-3-4-5" />
+    <text
+       x="900.98328"
+       y="347.8866"
+       class="tap"
+       id="text8-0-8-3-0"
        style="dominant-baseline:middle;text-anchor:middle">P1.06</text>
     <g
        transform="translate(55.546678,123.51005)"
@@ -547,7 +622,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">5</text>
     </g>
     <g
-       transform="translate(643.54668,109.51005)"
+       transform="translate(538.28015,109.51005)"
        class="key keypos-6"
        id="g357-0">
       <rect
@@ -567,7 +642,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">6</text>
     </g>
     <g
-       transform="translate(699.54668,102.51005)"
+       transform="translate(594.28015,102.51005)"
        class="key keypos-7"
        id="g363-3">
       <rect
@@ -587,7 +662,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">7</text>
     </g>
     <g
-       transform="translate(755.54668,95.510054)"
+       transform="translate(650.28015,95.510054)"
        class="key keypos-8"
        id="g369-8">
       <rect
@@ -607,7 +682,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">8</text>
     </g>
     <g
-       transform="translate(811.54668,102.51005)"
+       transform="translate(706.28015,102.51005)"
        class="key keypos-9"
        id="g375-9">
       <rect
@@ -627,7 +702,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">9</text>
     </g>
     <g
-       transform="translate(867.54668,116.51005)"
+       transform="translate(762.28015,116.51005)"
        class="key keypos-10"
        id="g381-7">
       <rect
@@ -647,7 +722,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">0</text>
     </g>
     <g
-       transform="translate(923.54668,123.51005)"
+       transform="translate(818.28015,123.51005)"
        class="key keypos-11"
        id="g387-0">
       <rect
@@ -787,7 +862,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">T</text>
     </g>
     <g
-       transform="translate(643.54668,165.51005)"
+       transform="translate(538.28015,165.51005)"
        class="key keypos-18"
        id="g429-9">
       <rect
@@ -807,7 +882,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">Y</text>
     </g>
     <g
-       transform="translate(699.54668,158.51005)"
+       transform="translate(594.28015,158.51005)"
        class="key keypos-19"
        id="g435-6">
       <rect
@@ -827,7 +902,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">U</text>
     </g>
     <g
-       transform="translate(755.54668,151.51005)"
+       transform="translate(650.28015,151.51005)"
        class="key keypos-20"
        id="g441-5">
       <rect
@@ -847,7 +922,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">I</text>
     </g>
     <g
-       transform="translate(811.54668,158.51005)"
+       transform="translate(706.28015,158.51005)"
        class="key keypos-21"
        id="g447-7">
       <rect
@@ -867,7 +942,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">O</text>
     </g>
     <g
-       transform="translate(867.54668,172.51005)"
+       transform="translate(762.28015,172.51005)"
        class="key keypos-22"
        id="g453-8">
       <rect
@@ -887,7 +962,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">P</text>
     </g>
     <g
-       transform="translate(923.54668,179.51005)"
+       transform="translate(818.28015,179.51005)"
        class="key keypos-23"
        id="g459-3">
       <rect
@@ -1027,7 +1102,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">G</text>
     </g>
     <g
-       transform="translate(643.54668,221.51005)"
+       transform="translate(538.28015,221.51005)"
        class="key keypos-30"
        id="g501-6">
       <rect
@@ -1047,7 +1122,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">H</text>
     </g>
     <g
-       transform="translate(699.54668,214.51005)"
+       transform="translate(594.28015,214.51005)"
        class="key keypos-31"
        id="g507-2">
       <rect
@@ -1067,7 +1142,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">J</text>
     </g>
     <g
-       transform="translate(755.54668,207.51005)"
+       transform="translate(650.28015,207.51005)"
        class="key keypos-32"
        id="g513-1">
       <rect
@@ -1087,7 +1162,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">K</text>
     </g>
     <g
-       transform="translate(811.54668,214.51005)"
+       transform="translate(706.28015,214.51005)"
        class="key keypos-33"
        id="g519-4">
       <rect
@@ -1107,7 +1182,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">L</text>
     </g>
     <g
-       transform="translate(867.54668,228.51005)"
+       transform="translate(762.28015,228.51005)"
        class="key keypos-34"
        id="g525-6">
       <rect
@@ -1127,7 +1202,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">;</text>
     </g>
     <g
-       transform="translate(923.54668,235.51005)"
+       transform="translate(818.28015,235.51005)"
        class="key keypos-35"
        id="g531-1">
       <rect
@@ -1267,7 +1342,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">B</text>
     </g>
     <g
-       transform="translate(391.54668,249.51005)"
+       transform="translate(335.54673,333.51055)"
        class="key keypos-42"
        id="g573-6">
       <rect
@@ -1287,7 +1362,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">[</text>
     </g>
     <g
-       transform="translate(587.54668,249.51005)"
+       transform="translate(538.2802,333.51055)"
        class="key keypos-43"
        id="g579-1">
       <rect
@@ -1307,7 +1382,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">]</text>
     </g>
     <g
-       transform="translate(643.54668,277.51005)"
+       transform="translate(538.28015,277.51005)"
        class="key keypos-44"
        id="g585-5">
       <rect
@@ -1327,7 +1402,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">N</text>
     </g>
     <g
-       transform="translate(699.54668,270.51005)"
+       transform="translate(594.28015,270.51005)"
        class="key keypos-45"
        id="g591-9">
       <rect
@@ -1347,7 +1422,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">M</text>
     </g>
     <g
-       transform="translate(755.54668,263.51005)"
+       transform="translate(650.28015,263.51005)"
        class="key keypos-46"
        id="g597-5">
       <rect
@@ -1367,7 +1442,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">,</text>
     </g>
     <g
-       transform="translate(811.54668,270.51005)"
+       transform="translate(706.28015,270.51005)"
        class="key keypos-47"
        id="g603-6">
       <rect
@@ -1387,7 +1462,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">.</text>
     </g>
     <g
-       transform="translate(867.54668,284.51005)"
+       transform="translate(762.28015,284.51005)"
        class="key keypos-48"
        id="g609-3">
       <rect
@@ -1407,7 +1482,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">/</text>
     </g>
     <g
-       transform="translate(923.54668,291.51005)"
+       transform="translate(818.28015,291.51005)"
        class="key keypos-49"
        id="g615-0">
       <rect
@@ -1427,7 +1502,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">RSHFT</text>
     </g>
     <g
-       transform="translate(195.54668,326.51005)"
+       transform="translate(111.54673,340.51055)"
        class="key keypos-50"
        id="g621-8">
       <rect
@@ -1447,7 +1522,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">LALT</text>
     </g>
     <g
-       transform="translate(251.54668,327.51005)"
+       transform="translate(167.54673,326.51055)"
        class="key keypos-51"
        id="g627-9">
       <rect
@@ -1467,7 +1542,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">LGUI</text>
     </g>
     <g
-       transform="translate(307.54668,333.51005)"
+       transform="translate(223.54673,319.51055)"
        class="key keypos-52"
        id="g633-7">
       <rect
@@ -1487,7 +1562,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">Lower</text>
     </g>
     <g
-       transform="rotate(30,-433.56489,871.26672)"
+       transform="matrix(0.9628094,-0.00194197,8.6156869e-4,1.0099995,278.95755,341.15884)"
        class="key keypos-53"
        id="g639-0">
       <rect
@@ -1498,7 +1573,8 @@ path.combo {
          width="52"
          height="80"
          class="key"
-         id="rect635-8" />
+         id="rect635-8"
+         transform="scale(-1)" />
       <text
          x="0"
          y="0"
@@ -1507,7 +1583,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">SPACE</text>
     </g>
     <g
-       transform="rotate(-30,923.11157,-955.74635)"
+       transform="rotate(0.29693883,-65425.865,114805.33)"
        class="key keypos-54"
        id="g645-9">
       <rect
@@ -1527,7 +1603,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">RET</text>
     </g>
     <g
-       transform="translate(671.54668,333.51005)"
+       transform="translate(650.2802,319.51055)"
        class="key keypos-55"
        id="g651-6">
       <rect
@@ -1547,7 +1623,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">Raise</text>
     </g>
     <g
-       transform="translate(727.54668,327.51005)"
+       transform="translate(706.2802,326.51055)"
        class="key keypos-56"
        id="g657-0">
       <rect
@@ -1567,7 +1643,7 @@ path.combo {
          style="dominant-baseline:middle;text-anchor:middle">BSPC</text>
     </g>
     <g
-       transform="translate(783.54668,327.51005)"
+       transform="translate(762.3597,340.43105)"
        class="key keypos-57"
        id="g663-9">
       <rect

--- a/docs/build-guides/lily58-wireless/troubleshooting.mdx
+++ b/docs/build-guides/lily58-wireless/troubleshooting.mdx
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 import Lily58Pins from './lily58_pins.svg';
 
-# Troubleshooting
+# Troubleshooting & Pinouts
 
 If you're running into issues with your keyboard, check out our [Troubleshooting](/troubleshooting) page for common issues and solutions. If you're still having trouble, please reach out to use on [Discord](https://typeractive.xyz/discord)!
 
@@ -12,6 +12,27 @@ If you're running into issues with your keyboard, check out our [Troubleshooting
 
 Below you can see which pins on the nice!nano lineup with the Lily58's rows and columns.
 
-If you're having issues with a specific row or column, use this diagram along with the [troubleshoting guide](/troubleshooting/rows-columns-not-working) to help you diagnose the issue.
+If you're having issues with a specific row or column, use this diagram along with the [troubleshooting guide](/troubleshooting/rows-columns-not-working) to help you diagnose the issue.
 
 <Lily58Pins />
+
+Definitions can be found in the dtsi for the [Rows](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/lily58/lily58.dtsi), [Left column](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/lily58/lily58_left.overlay) and [Right column](https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/lily58/lily58_right.overlay)
+
+## Spare pins
+
+Not all the pins on the nice!nano are used and depending on if you have a nice!view or not the following pins are available
+
+| 🚫 nice!view  | ✅ nice!view |
+|--------------|---------------|
+|    P0.06  |  ~~P0.06~~  |
+|    P0.08  |  P0.08   |
+|    P0.17  |  ~~P0.17~~  |
+|    P0.20  |  ~~P0.20~~  |
+|    P0.22  |  P0.22  |
+|    P0.29  |  P0.29  |
+|    P0.31  |  P0.31  |
+|    P1.01^  |  P1.01^ |
+|    P1.02^  |  P1.02^ |
+|    P1.07^  |  P1.07^ |
+
+^ These pins are on the middle of the board rather than on the edges.


### PR DESCRIPTION
I'm proposing two minor changes for the build guide for the Lily58 (and happy to do the same for the Corne if this is accepted, it's basically the same idea) as I was finding the diagram for row/col pinouts was ambiguous, and didn't mention the nice!view.

Specifically the original diagram isn't super clear around the columns for `LALT`/`LGUI`/`Lower`/`Space`/`[`. `[` especially is visually implied to be on either row `P1.04` pr `P0.11`, so I've rearranged it so the rows/cols line up. I've also duplicated the row labels to the left. 

I've added the unused pins, distinguishing between nice!view and non-nice!view setups, and also added the word "pinouts" to the section title.

Adding links to the .dtsi might be overkill, but I imagine if someone is just getting into ZMK it'll help to go straight to that portion of the tree instead of having to drill down.